### PR TITLE
Production 環境で、bundle.js ロードを高速化

### DIFF
--- a/app.js
+++ b/app.js
@@ -32,15 +32,22 @@ app.use(cookieParser());
 app.use(express.static(path.join(__dirname, 'public')));
 app.use('/upmain', express.static(path.join(__dirname, 'public')));
 
-app.use((req, res, next) => {
+// Upload Application Routing
+app.use('/upload', (req, res, next) => {
   res.header('Cache-Control', 'private, no-cache, no-store, must-revalidate');
   res.header('Expires', '-1');
   res.header('Pragma', 'no-cache');
   next();
 });
-
-// Application Main Routing
 app.use('/upload', uploader);
+
+// Login Application Routing
+app.use('/login', (req, res, next) => {
+  res.header('Cache-Control', 'private, no-cache, no-store, must-revalidate');
+  res.header('Expires', '-1');
+  res.header('Pragma', 'no-cache');
+  next();
+});
 app.use('/login', login);
 
 // catch 404 and forward to error handler

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,7 @@ module.exports = {
     filename: 'bundle.js',
     path: path.resolve(__dirname, 'public'),
   },
-  devtool: 'inline-source-map',
+  devtool: 'cheap-module-eval-source-map',
   module: {
     loaders: [
       {


### PR DESCRIPTION
1. app.js で Cache を無効にするURLを限定
2. webpack の devtool の指定を変更
 inline-source-map -> cheap-module-eval-source-map
 これにより、Production bundle.js が 5.8M から 4.0M にサイズダウン